### PR TITLE
return timestamps as zoned at UTC

### DIFF
--- a/src/li/ktt/xml/XmlGenerator.java
+++ b/src/li/ktt/xml/XmlGenerator.java
@@ -7,6 +7,9 @@ import com.intellij.database.remote.jdbc.LobInfo;
 import li.ktt.datagrid.DataHelper;
 import li.ktt.settings.ExtractorProperties;
 
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import static com.intellij.openapi.util.text.StringUtil.escapeXml;
@@ -85,6 +88,9 @@ public class XmlGenerator {
     private String extractStringValue(final Object value) {
         if (value instanceof TimeZonedTimestamp) {
             return ((TimeZonedTimestamp) value).getValue().toString();
+        }
+        if (value instanceof Timestamp) {
+            return Timestamp.valueOf(LocalDateTime.ofInstant(((Timestamp) value).toInstant(), ZoneOffset.UTC)).toString();
         }
         if (value instanceof LobInfo.ClobInfo) {
             return ((LobInfo.ClobInfo) value).data;


### PR DESCRIPTION
When the original database column has a datetime, but contains
no zone information, calling toString() would interpret it as a
timestamp in the local timezone. So if the time was at 00:00,
this would be transformed to 01:00 for dates in CET and
02:00 for dates in CEST.