### PR TITLE
Fix compatibility with 2022.2

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -45,7 +45,7 @@
     ]]>
   </change-notes>
 
-  <idea-version since-build="201.6668.121"/>
+  <idea-version since-build="222.2270.31"/>
 
   <depends>com.intellij.modules.ultimate</depends>
   <depends>com.intellij.database</depends>

--- a/src/li/ktt/QueryToXMLConverter.java
+++ b/src/li/ktt/QueryToXMLConverter.java
@@ -6,6 +6,8 @@ import com.intellij.database.dataSource.DatabaseConnection;
 import com.intellij.database.dataSource.connection.DGDepartment;
 import com.intellij.database.datagrid.DataConsumer.Column;
 import com.intellij.database.datagrid.DataConsumer.Row;
+import com.intellij.database.datagrid.GridColumn;
+import com.intellij.database.datagrid.GridRow;
 import com.intellij.database.psi.DbDataSource;
 import com.intellij.database.psi.DbPsiFacade;
 import com.intellij.database.remote.jdbc.RemoteDatabaseMetaData;
@@ -161,8 +163,8 @@ public class QueryToXMLConverter extends PsiElementBaseIntentionAction implement
                 }
             }
 
-            final List<Column> columns = constructColumns(metaData);
-            final List<Row> rows = constructRows(metaData, resultSet);
+            final List<GridColumn> columns = constructColumns(metaData);
+            final List<GridRow> rows = constructRows(metaData, resultSet);
             final String tableName = tableNames.iterator().next();
             final String schema = StringUtil.isNotEmpty(metaData.getSchemaName(1))
                     ? metaData.getSchemaName(1)
@@ -263,9 +265,9 @@ public class QueryToXMLConverter extends PsiElementBaseIntentionAction implement
     }
 
     @NotNull
-    private List<Row> constructRows(final RemoteResultSetMetaData metaData,
+    private List<GridRow> constructRows(final RemoteResultSetMetaData metaData,
                                     final RemoteResultSet resultSet) throws SQLException, RemoteException {
-        final List<Row> rows = new LinkedList<>();
+        final List<GridRow> rows = new LinkedList<>();
         int rowNum = 0;
         while (resultSet.next()) {
             List<Object> values = new LinkedList<>();
@@ -279,9 +281,9 @@ public class QueryToXMLConverter extends PsiElementBaseIntentionAction implement
     }
 
     @NotNull
-    private List<Column> constructColumns(final RemoteResultSetMetaData metaData)
+    private List<GridColumn> constructColumns(final RemoteResultSetMetaData metaData)
             throws SQLException, RemoteException {
-        final List<Column> columns = new LinkedList<>();
+        final List<GridColumn> columns = new LinkedList<>();
 
         for (int i = 1; i <= metaData.getColumnCount(); i++) {
             columns.add(new Column(i - 1,

--- a/src/li/ktt/datagrid/DataGridHelper.java
+++ b/src/li/ktt/datagrid/DataGridHelper.java
@@ -1,10 +1,6 @@
 package li.ktt.datagrid;
 
-import com.intellij.database.datagrid.DataConsumer.Column;
-import com.intellij.database.datagrid.DataConsumer.Row;
-import com.intellij.database.datagrid.DataGrid;
-import com.intellij.database.datagrid.DataGridUtil;
-import com.intellij.database.datagrid.GridModel;
+import com.intellij.database.datagrid.*;
 import com.intellij.database.model.DasTable;
 import com.intellij.database.run.ui.DataAccessType;
 import com.intellij.openapi.util.text.StringUtil;
@@ -22,9 +18,9 @@ public class DataGridHelper implements DataHelper {
 
     private final String tableName;
 
-    private final List<Column> filteredColumns;
+    private final List<GridColumn> filteredColumns;
 
-    private final List<Row> rows;
+    private final List<GridRow> rows;
 
     private final ExcludedColumns excludedColumns;
 
@@ -38,7 +34,7 @@ public class DataGridHelper implements DataHelper {
     }
 
 
-    public DataGridHelper(String schemaName, String tableName, List<Column> filteredColumns, List<Row> rows) {
+    public DataGridHelper(String schemaName, String tableName, List<GridColumn> filteredColumns, List<GridRow> rows) {
         this.schemaName = schemaName;
         this.tableName = tableName;
         this.excludedColumns = new ExcludedColumns("");
@@ -57,35 +53,35 @@ public class DataGridHelper implements DataHelper {
     }
 
     @Override
-    public List<Column> getFilteredColumns() {
+    public List<GridColumn> getFilteredColumns() {
         return filteredColumns;
     }
 
     @Override
-    public List<Row> getRows() {
+    public List<GridRow> getRows() {
         return rows;
     }
 
     @NotNull
-    private List<Row> getSelectedRows(final DataGrid dataGrid) {
+    private List<GridRow> getSelectedRows(final DataGrid dataGrid) {
         return getDataModel(dataGrid).getRows(dataGrid.getSelectionModel().getSelectedRows());
     }
 
     @NotNull
-    private GridModel<Row, Column> getDataModel(final DataGrid dataGrid) {
+    private GridModel<GridRow, GridColumn> getDataModel(final DataGrid dataGrid) {
         return dataGrid.getDataModel(DataAccessType.DATABASE_DATA);
     }
 
     @NotNull
-    private List<Column> getSelectedColumns(final DataGrid dataGrid) {
+    private List<GridColumn> getSelectedColumns(final DataGrid dataGrid) {
         return getDataModel(dataGrid).getColumns(dataGrid.getSelectionModel().getSelectedColumns());
     }
 
     @Nullable
     private String initTableName(final DataGrid dataGrid) {
         DasTable table = DataGridUtil.getDatabaseTable(dataGrid);
-        final List<Column> columns = getDataModel(dataGrid).getColumns();
-        String name = columns.isEmpty() ? null : columns.get(0).table;
+        final List<GridColumn> columns = getDataModel(dataGrid).getColumns();
+        String name = columns.isEmpty() || !(columns.get(0) instanceof JdbcGridColumn) ? null : ((JdbcGridColumn) columns.get(0)).getTable();
         if ((name == null || name.isEmpty()) && table != null) {
             return table.getName();
         }
@@ -95,18 +91,18 @@ public class DataGridHelper implements DataHelper {
     @Nullable
     private String initSchemaName(final DataGrid dataGrid) {
         DasTable table = DataGridUtil.getDatabaseTable(dataGrid);
-        final List<Column> columns = getDataModel(dataGrid).getColumns();
-        String name = columns.isEmpty() ? null : columns.get(0).schema;
+        final List<GridColumn> columns = getDataModel(dataGrid).getColumns();
+        String name = columns.isEmpty() || !(columns.get(0) instanceof JdbcGridColumn) ? null : ((JdbcGridColumn) columns.get(0)).getSchema();
         if (StringUtil.isEmpty(name) && table != null && table.getDasParent() != null) {
             name = table.getDasParent().getName();
         }
         return name;
     }
 
-    private List<Column> initFilteredColumns(final List<Column> allColumns) {
-        List<Column> filtered = new LinkedList<Column>();
-        for (final Column column : allColumns) {
-            if (this.excludedColumns.canBeAdded(this.tableName + "." + column.name)) {
+    private List<GridColumn> initFilteredColumns(final List<GridColumn> allColumns) {
+        List<GridColumn> filtered = new LinkedList<>();
+        for (final GridColumn column : allColumns) {
+            if (this.excludedColumns.canBeAdded(this.tableName + "." + column.getName())) {
                 filtered.add(column);
             }
         }

--- a/src/li/ktt/datagrid/DataHelper.java
+++ b/src/li/ktt/datagrid/DataHelper.java
@@ -2,6 +2,8 @@ package li.ktt.datagrid;
 
 import com.intellij.database.datagrid.DataConsumer.Column;
 import com.intellij.database.datagrid.DataConsumer.Row;
+import com.intellij.database.datagrid.GridColumn;
+import com.intellij.database.datagrid.GridRow;
 
 import java.util.List;
 
@@ -10,7 +12,7 @@ public interface DataHelper {
 
     String getTableName();
 
-    List<Column> getFilteredColumns();
+    List<GridColumn> getFilteredColumns();
 
-    List<Row> getRows();
+    List<GridRow> getRows();
 }

--- a/src/li/ktt/datagrid/ResultSetHelper.java
+++ b/src/li/ktt/datagrid/ResultSetHelper.java
@@ -2,8 +2,11 @@ package li.ktt.datagrid;
 
 import com.intellij.database.datagrid.DataConsumer.Column;
 import com.intellij.database.datagrid.DataConsumer.Row;
+import com.intellij.database.datagrid.GridColumn;
+import com.intellij.database.datagrid.GridRow;
 import li.ktt.settings.ExcludedColumns;
 import li.ktt.settings.ExtractorProperties;
+import net.miginfocom.layout.Grid;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -14,17 +17,17 @@ public class ResultSetHelper implements DataHelper {
 
     private final String tableName;
 
-    private final List<Column> filteredColumns;
+    private final List<GridColumn> filteredColumns;
 
-    private final List<Row> rows;
+    private final List<GridRow> rows;
 
     private final ExcludedColumns excludedColumns;
 
     public ResultSetHelper(ExtractorProperties extractorProperties,
                            final String schemaName,
                            final String tableName,
-                           final List<Column> columns,
-                           final List<Row> rows) {
+                           final List<GridColumn> columns,
+                           final List<GridRow> rows) {
         this.schemaName = schemaName;
         this.tableName = tableName;
         String excludedColumnsString = extractorProperties.getExcludeColumns();
@@ -44,19 +47,19 @@ public class ResultSetHelper implements DataHelper {
     }
 
     @Override
-    public List<Column> getFilteredColumns() {
+    public List<GridColumn> getFilteredColumns() {
         return filteredColumns;
     }
 
     @Override
-    public List<Row> getRows() {
+    public List<GridRow> getRows() {
         return rows;
     }
 
-    private List<Column> initFilteredColumns(final List<Column> allColumns) {
-        List<Column> filtered = new LinkedList<>();
-        for (final Column column : allColumns) {
-            if (this.excludedColumns.canBeAdded(this.tableName + "." + column.name)) {
+    private List<GridColumn> initFilteredColumns(final List<GridColumn> allColumns) {
+        List<GridColumn> filtered = new LinkedList<>();
+        for (final GridColumn column : allColumns) {
+            if (this.excludedColumns.canBeAdded(this.tableName + "." + column.getName())) {
                 filtered.add(column);
             }
         }

--- a/src/li/ktt/xml/XmlGenerator.java
+++ b/src/li/ktt/xml/XmlGenerator.java
@@ -1,7 +1,7 @@
 package li.ktt.xml;
 
-import com.intellij.database.datagrid.DataConsumer.Column;
-import com.intellij.database.datagrid.DataConsumer.Row;
+import com.intellij.database.datagrid.GridColumn;
+import com.intellij.database.datagrid.GridRow;
 import com.intellij.database.extractors.tz.TimeZonedTimestamp;
 import com.intellij.database.remote.jdbc.LobInfo;
 import li.ktt.datagrid.DataHelper;
@@ -45,20 +45,20 @@ public class XmlGenerator {
     }
 
     public XmlGenerator appendRows() {
-        for (Row row : data.getRows()) {
+        for (GridRow row : data.getRows()) {
             appendRow(row);
         }
         return this;
     }
 
-    public XmlGenerator appendRows(List<Row> rows) {
-        for (Row row : rows) {
+    public XmlGenerator appendRows(List<GridRow> rows) {
+        for (GridRow row : rows) {
             appendRow(row);
         }
         return this;
     }
 
-    public void appendRow(final Row row) {
+    public void appendRow(final GridRow row) {
         this.rowSize++;
         builder.append("<");
         if (extractorProperties.isIncludeSchema()) {
@@ -66,18 +66,18 @@ public class XmlGenerator {
         }
         builder.append(data.getTableName()).append(" ");
 
-        for (final Column column : data.getFilteredColumns()) {
+        for (final GridColumn column : data.getFilteredColumns()) {
             appendField(builder, row, column);
         }
         builder.append("/>\n");
     }
 
     private void appendField(final StringBuilder builder,
-                             final Row row,
-                             final Column column) {
-        final String columnValue = extractStringValue(row.values[column.columnNum]);
+                             final GridRow row,
+                             final GridColumn column) {
+        final String columnValue = extractStringValue(column.getValue(row));
         if (notNullOrNullAllowed(columnValue) && notEmptyOrEmptyAllowed(columnValue)) {
-            builder.append(column.name).append("=\"");
+            builder.append(column.getName()).append("=\"");
             if (columnValue != null) {
                 builder.append(escapeXmlEntities(columnValue));
             }

--- a/test/li/ktt/datagrid/DataGridHelperTest.java
+++ b/test/li/ktt/datagrid/DataGridHelperTest.java
@@ -1,11 +1,8 @@
 package li.ktt.datagrid;
 
+import com.intellij.database.datagrid.*;
 import com.intellij.database.datagrid.DataConsumer.Column;
 import com.intellij.database.datagrid.DataConsumer.Row;
-import com.intellij.database.datagrid.DataGrid;
-import com.intellij.database.datagrid.GridModel;
-import com.intellij.database.datagrid.ModelIndexSet;
-import com.intellij.database.datagrid.SelectionModel;
 import com.intellij.database.run.ui.DataAccessType;
 import li.ktt.settings.ExtractorProperties;
 import org.junit.Before;
@@ -28,20 +25,20 @@ public class DataGridHelperTest {
     private DataGrid dataGridMock;
 
     @Mock
-    private SelectionModel<Row, Column> selectionModelMock;
+    private SelectionModel<GridRow, GridColumn> selectionModelMock;
 
     @Mock
-    private ModelIndexSet<Row> selectedRowsMock;
+    private ModelIndexSet<GridRow> selectedRowsMock;
 
     @Mock
-    private ModelIndexSet<Column> selectedColumnsMock;
+    private ModelIndexSet<GridColumn> selectedColumnsMock;
 
     @Mock
-    private GridModel<Row, Column> dataModelMock;
+    private GridModel<GridRow, GridColumn> dataModelMock;
 
-    private final List<Row> sampleRows = new ArrayList<Row>();
+    private final List<GridRow> sampleRows = new ArrayList<>();
 
-    private final List<Column> sampleColumns = new ArrayList<Column>();
+    private final List<GridColumn> sampleColumns = new ArrayList<>();
 
     private final ExtractorProperties defaultProperties = new ExtractorProperties(true, true, true, "", null);
 
@@ -75,7 +72,7 @@ public class DataGridHelperTest {
         DataGridHelper data = new DataGridHelper(defaultProperties, dataGridMock);
 
         // when
-        List<Row> result = data.getRows();
+        List<GridRow> result = data.getRows();
 
         // then
         assertEquals(sampleRows, result);
@@ -87,7 +84,7 @@ public class DataGridHelperTest {
         DataGridHelper data = new DataGridHelper(defaultProperties, dataGridMock);
 
         // then
-        List<Column> result = data.getFilteredColumns();
+        List<GridColumn> result = data.getFilteredColumns();
         assertEquals(sampleColumns, result);
     }
 
@@ -104,7 +101,7 @@ public class DataGridHelperTest {
     @Test
     public void shouldReturnSchemaAndTableNamesFromFirstColumn() {
         // given
-        List<Column> localSampleColumns = new ArrayList<Column>();
+        List<GridColumn> localSampleColumns = new ArrayList<>();
         localSampleColumns.add(new Column(1, "superCol", 1, "type", "String", 1, 2, "catalog", "schema201", "superTable201"));
         localSampleColumns.add(new Column(2, "superCol", 1, "type", "String", 1, 2, "catalog", "schema203", "superTable201"));
         when(dataModelMock.getColumns()).thenReturn(localSampleColumns);

--- a/test/li/ktt/xml/XmlGeneratorTest.java
+++ b/test/li/ktt/xml/XmlGeneratorTest.java
@@ -2,6 +2,8 @@ package li.ktt.xml;
 
 import com.intellij.database.datagrid.DataConsumer.Column;
 import com.intellij.database.datagrid.DataConsumer.Row;
+import com.intellij.database.datagrid.GridColumn;
+import com.intellij.database.datagrid.GridRow;
 import li.ktt.datagrid.DataGridHelper;
 import li.ktt.settings.ExtractorProperties;
 import org.junit.BeforeClass;
@@ -16,9 +18,9 @@ public class XmlGeneratorTest {
 
     private static final String NO_EXCLUDED_COLUMNS = "";
 
-    private static final List<Column> columns = new ArrayList<Column>();
+    private static final List<GridColumn> columns = new ArrayList<>();
 
-    private static final List<Row> rows = new ArrayList<Row>();
+    private static final List<GridRow> rows = new ArrayList<>();
 
     @BeforeClass
     public static void before() {


### PR DESCRIPTION
Hello @kTT!

Could you please recompile and upload new version of your plugin to marketplace?

I'm a developer from DataGrip
For the last several months I've been doing lot's of refactorings to make it possible for other IDEs to reuse our table editor. And it unfortunately led to a couple of API breakages. Your plugin will not be compatible with IDEs starting from 2022.2 version.

Your plugin is being downloaded ~40 times every month so it will be great if you could upload new version to marketplace 🙏 